### PR TITLE
Added extra jsonindent checking

### DIFF
--- a/decode-config.py
+++ b/decode-config.py
@@ -241,7 +241,7 @@ DEFAULTS            = {
     },
     'jsonformat':
     {
-        'jsonindent':   None,
+        'jsonindent':   4,
         'jsoncompact':  False,
         'jsonsort':     True,
         'jsonhidepw':   False,
@@ -2925,7 +2925,7 @@ def Backup(backupfile, backupfileformat, encode_cfg, decode_cfg, configmapping):
             message("Writing backup file '{}' ({} format)".format(backup_filename, fileformat), type_=LogType.INFO)
         try:
             with open(backup_filename, "w") as backupfp:
-                json.dump(configmapping, backupfp, sort_keys=args.jsonsort, indent=None if args.jsonindent < 0 else args.jsonindent, separators=(',', ':') if args.jsoncompact else (', ', ': ') )
+                json.dump(configmapping, backupfp, sort_keys=args.jsonsort, indent=None if (args.jsonindent is None or args.jsonindent<0) < 0 else args.jsonindent, separators=(',', ':') if args.jsoncompact else (', ', ': ') )
         except Exception as e:
             exit(e.args[0], "'{}' {}".format(backup_filename, e[1]),line=inspect.getlineno(inspect.currentframe()))
 
@@ -3339,7 +3339,7 @@ if __name__ == "__main__":
     # json screen output
     if (args.backupfile is None and args.restorefile is None) or args.output:
         if args.outputformat == 'json':
-            print(json.dumps(configmapping, sort_keys=args.jsonsort, indent=None if args.jsonindent<0 else args.jsonindent, separators=(',', ':') if args.jsoncompact else (', ', ': ') ))
+            print(json.dumps(configmapping, sort_keys=args.jsonsort, indent=None if (args.jsonindent is None or args.jsonindent<0) else args.jsonindent, separators=(',', ':') if args.jsoncompact else (', ', ': ') ))
 
         if args.outputformat == 'cmnd' or args.outputformat == 'command':
             tasmotacmnds = Mapping2Cmnd(decode_cfg, configmapping)


### PR DESCRIPTION
Two changes to avoid a "NoneType to int" error when outputting JSON; changed the default of jsonindent to a value (4) and added extra checking of the jsonindent value in both screen and file output.