### PR TITLE
Update publish.yml to use pinned version for pypi publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Package
       run: make build-pypi
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
As per https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-

With #58 we it'll ensure we will get notified of newer pipeline changes.