### PR TITLE
Leverage Python 3.12 for build

### DIFF
--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       # Install pip and pyinstaller
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build wheel
+        pip install build wheel setuptools
         pip install -r requirements.txt
     - name: Package
       run: make build-pypi


### PR DESCRIPTION
Should fix the issue you mentioned on the comment here https://github.com/tasmota/decode-config/pull/39#issuecomment-2557724067

```
❯ tree dist/
dist/
├── decode_config-14.4.1.1-py3-none-any.whl
└── decode_config-14.4.1.1.tar.gz
```

Looks like the whole stack around setup.py could do with a rework longer term though as it spat out another deprecated notice.


<details>

```
decode-config on  fix-build [!] via 🐍 v3.12.7 (.venv) 
❯ make
rm -rf build/
rm -rf dist/
rm -rf *.egg-info
python setup.py sdist bdist_wheel
running sdist
running egg_info
creating decode_config.egg-info
writing decode_config.egg-info/PKG-INFO
writing dependency_links to decode_config.egg-info/dependency_links.txt
writing requirements to decode_config.egg-info/requires.txt
writing top-level names to decode_config.egg-info/top_level.txt
writing manifest file 'decode_config.egg-info/SOURCES.txt'
reading manifest file 'decode_config.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'decode_config.egg-info/SOURCES.txt'
running check
creating decode_config-14.4.1.1
creating decode_config-14.4.1.1/decode_config.egg-info
copying files to decode_config-14.4.1.1...
copying LICENSE -> decode_config-14.4.1.1
copying README.md -> decode_config-14.4.1.1
copying decode-config.py -> decode_config-14.4.1.1
copying setup.py -> decode_config-14.4.1.1
copying decode_config.egg-info/PKG-INFO -> decode_config-14.4.1.1/decode_config.egg-info
copying decode_config.egg-info/SOURCES.txt -> decode_config-14.4.1.1/decode_config.egg-info
copying decode_config.egg-info/dependency_links.txt -> decode_config-14.4.1.1/decode_config.egg-info
copying decode_config.egg-info/requires.txt -> decode_config-14.4.1.1/decode_config.egg-info
copying decode_config.egg-info/top_level.txt -> decode_config-14.4.1.1/decode_config.egg-info
copying decode_config.egg-info/SOURCES.txt -> decode_config-14.4.1.1/decode_config.egg-info
Writing decode_config-14.4.1.1/setup.cfg
creating dist
Creating tar archive
removing 'decode_config-14.4.1.1' (and everything under it)
running bdist_wheel
running build
running build_py
running build_scripts
creating build/scripts-3.12
copying and adjusting decode-config.py -> build/scripts-3.12
changing mode of build/scripts-3.12/decode-config.py from 644 to 755
/home/malachi/code/python/decode-config/.venv/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
warning: install_lib: 'build/lib' does not exist -- no Python modules to install

running install_egg_info
Copying decode_config.egg-info to build/bdist.linux-x86_64/wheel/./decode_config-14.4.1.1-py3.12.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/decode_config-14.4.1.1.data/scripts
copying build/scripts-3.12/decode-config.py -> build/bdist.linux-x86_64/wheel/decode_config-14.4.1.1.data/scripts
changing mode of build/bdist.linux-x86_64/wheel/decode_config-14.4.1.1.data/scripts/decode-config.py to 755
creating build/bdist.linux-x86_64/wheel/decode_config-14.4.1.1.dist-info/WHEEL
creating 'dist/decode_config-14.4.1.1-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'decode_config-14.4.1.1.data/scripts/decode-config.py'
adding 'decode_config-14.4.1.1.dist-info/LICENSE'
adding 'decode_config-14.4.1.1.dist-info/METADATA'
adding 'decode_config-14.4.1.1.dist-info/WHEEL'
adding 'decode_config-14.4.1.1.dist-info/top_level.txt'
adding 'decode_config-14.4.1.1.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
```

</details>